### PR TITLE
feat(M1.1): Implement initial Sampler recording feature

### DIFF
--- a/app/src/main/java/com/example/theone/features/sampler/SamplerScreen.kt
+++ b/app/src/main/java/com/example/theone/features/sampler/SamplerScreen.kt
@@ -1,0 +1,290 @@
+package com.example.theone.features.sampler
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel // Required for viewModel()
+
+// Assuming SamplerViewModel is in the same package
+// Assuming RecordingState is accessible
+
+@Composable
+fun SamplerScreen(samplerViewModel: SamplerViewModel = viewModel()) { // Placeholder for Hilt injection later
+
+    val recordingState by samplerViewModel.recordingState.collectAsState()
+    val inputLevel by samplerViewModel.inputLevel.collectAsState() // Simulated input level
+    val isThresholdEnabled by samplerViewModel.isThresholdRecordingEnabled.collectAsState()
+    val thresholdValue by samplerViewModel.thresholdValue.collectAsState()
+
+    var showNameSampleDialog by remember { mutableStateOf(false) }
+    var sampleName by remember { mutableStateOf("") }
+    var showAssignToPadDialog by remember { mutableStateOf(false) }
+    var selectedPadId by remember { mutableStateOf<String?>(null) }
+
+
+    // Update dialog visibility based on ViewModel state
+    LaunchedEffect(recordingState) {
+        if (recordingState == RecordingState.REVIEWING) {
+            showNameSampleDialog = true
+        } else {
+            showNameSampleDialog = false
+            showAssignToPadDialog = false // Also reset assign dialog if not reviewing
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Sampler (M1.1)") })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(16.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                // Input Source Selection (Placeholder)
+                Text("Input Source: Mic (Placeholder)", style = MaterialTheme.typography.subtitle1)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Live Input Level Meter
+                LinearProgressIndicator(
+                    progress = inputLevel, // ViewModel will provide this
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(String.format("Input Level: %.2f", inputLevel), style = MaterialTheme.typography.caption)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Threshold Recording
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = isThresholdEnabled,
+                        onCheckedChange = { samplerViewModel.toggleThresholdRecording(it) }
+                    )
+                    Text("Threshold Recording")
+                }
+                if (isThresholdEnabled) {
+                    Slider(
+                        value = thresholdValue,
+                        onValueChange = { samplerViewModel.setThresholdValue(it) },
+                        valueRange = 0.0f..1.0f,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    Text(String.format("Threshold: %.2f", thresholdValue))
+                }
+            }
+
+
+            // Controls
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                 Spacer(modifier = Modifier.height(32.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(
+                        onClick = { samplerViewModel.startRecordingPressed() },
+                        enabled = recordingState == RecordingState.IDLE || recordingState == RecordingState.REVIEWING
+                    ) {
+                        Icon(Icons.Filled.Mic, contentDescription = "Record")
+                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                        Text(if (recordingState == RecordingState.ARMED) "Armed" else "Record")
+                    }
+
+                    Button(
+                        onClick = { samplerViewModel.stopRecordingPressed() },
+                        enabled = recordingState == RecordingState.RECORDING || recordingState == RecordingState.ARMED
+                    ) {
+                        Icon(Icons.Filled.Stop, contentDescription = "Stop")
+                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                        Text("Stop")
+                    }
+                }
+                 Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = { samplerViewModel.playbackLastRecordingPressed() },
+                    enabled = recordingState == RecordingState.REVIEWING
+                ) {
+                    Text("Playback Last Recording")
+                }
+            }
+
+
+            if (showNameSampleDialog && recordingState == RecordingState.REVIEWING) {
+                NameSampleDialog(
+                    currentName = sampleName,
+                    onNameChange = { sampleName = it },
+                    onDismiss = {
+                        showNameSampleDialog = false
+                        samplerViewModel.discardRecording() // Or handle differently
+                    },
+                    onSave = { finalName ->
+                        showNameSampleDialog = false
+                        sampleName = finalName // update local state if needed
+                        // After naming, decide if we show assign to pad or just save
+                        showAssignToPadDialog = true // Let's assume we always ask for pad assignment next
+                    }
+                )
+            }
+
+            if (showAssignToPadDialog && recordingState == RecordingState.REVIEWING) {
+                AssignToPadDialog(
+                    onDismiss = {
+                        showAssignToPadDialog = false
+                        // If they dismiss pad assignment, still save with the name
+                        samplerViewModel.saveRecording(sampleName, null)
+                        sampleName = "" // Reset for next time
+                    },
+                    onAssign = { padId ->
+                        showAssignToPadDialog = false
+                        samplerViewModel.saveRecording(sampleName, padId)
+                        sampleName = "" // Reset for next time
+                    },
+                    onSkip = {
+                         showAssignToPadDialog = false
+                         samplerViewModel.saveRecording(sampleName, null) // Save without assigning
+                         sampleName = "" // Reset for next time
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp)) // Pushes controls up a bit
+        }
+    }
+}
+
+@Composable
+fun NameSampleDialog(
+    currentName: String,
+    onNameChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit
+) {
+    var tempName by remember(currentName) { mutableStateOf(currentName) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Name Your Sample") },
+        text = {
+            OutlinedTextField(
+                value = tempName,
+                onValueChange = { tempName = it },
+                label = { Text("Sample Name") },
+                singleLine = true
+            )
+        },
+        confirmButton = {
+            Button(onClick = {
+                if (tempName.isNotBlank()) {
+                    onSave(tempName)
+                }
+            }) {
+                Text("Save & Assign Pad")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text("Discard")
+            }
+        }
+    )
+}
+
+@Composable
+fun AssignToPadDialog(
+    onDismiss: () -> Unit,
+    onAssign: (String) -> Unit,
+    onSkip: () -> Unit
+) {
+    // Placeholder for pad selection. In a real app, this would be a grid or list of pads.
+    val padOptions = List(16) { "Pad ${it + 1}" } // Example: Pad 1 to Pad 16
+    var selectedPad by remember { mutableStateOf(padOptions[0]) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss, // User clicked outside
+        title = { Text("Assign to Pad (Optional)") },
+        text = {
+            Column {
+                Text("Select a pad to assign this sample to:")
+                Spacer(modifier = Modifier.height(8.dp))
+                // Simple dropdown for now
+                var expanded by remember { mutableStateOf(false) }
+                ExposedDropdownMenuBox(
+                    expanded = expanded,
+                    onExpandedChange = { expanded = !expanded }
+                ) {
+                    TextField(
+                        readOnly = true,
+                        value = selectedPad,
+                        onValueChange = { },
+                        label = { Text("Pad") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                        colors = ExposedDropdownMenuDefaults.textFieldColors()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = expanded,
+                        onDismissRequest = { expanded = false }
+                    ) {
+                        padOptions.forEach { selectionOption ->
+                            DropdownMenuItem(
+                                onClick = {
+                                    selectedPad = selectionOption
+                                    expanded = false
+                                }
+                            ) {
+                                Text(text = selectionOption)
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onAssign(selectedPad) }) {
+                Text("Assign and Save")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onSkip ) { // Changed to "Skip" for clarity
+                Text("Save without Assigning")
+            }
+        },
+         neutralButton = { // Added a neutral button for true dismiss/cancel
+            Button(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+
+// Preview for SamplerScreen
+@Preview(showBackground = true)
+@Composable
+fun DefaultSamplerScreenPreview() {
+    // Create a dummy SamplerViewModel for preview
+    // This requires AudioEngineControl and ProjectManager stubs for the preview
+    val dummyAudioEngine = object : AudioEngineControl {
+        override suspend fun startAudioRecording(filePathUri: String, inputDeviceId: String?) = true
+        override suspend fun stopAudioRecording(): SamplerViewModel.SampleMetadata? = SamplerViewModel.SampleMetadata("prev_id", "PreviewSample", "file://preview")
+        override fun getRecordingLevelPeak()= 0.5f
+        override fun isRecordingActive() = false
+    }
+    val dummyProjectManager = object : ProjectManager {
+        override suspend fun addSampleToPool(name: String, sourceFileUri: String, copyToProjectDir: Boolean) = SamplerViewModel.SampleMetadata("new_id", name, sourceFileUri)
+    }
+    val dummyViewModel = SamplerViewModel(dummyAudioEngine, dummyProjectManager)
+
+    MaterialTheme { // Ensure a MaterialTheme is applied for previews
+        SamplerScreen(samplerViewModel = dummyViewModel)
+    }
+}

--- a/app/src/main/java/com/example/theone/features/sampler/SamplerViewModel.kt
+++ b/app/src/main/java/com/example/theone/features/sampler/SamplerViewModel.kt
@@ -1,0 +1,231 @@
+package com.example.theone.features.sampler
+
+import android.util.Log // For logging pad assignment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// Placeholder for AudioEngineControl interface (C1)
+interface AudioEngineControl {
+    suspend fun startAudioRecording(filePathUri: String, inputDeviceId: String?): Boolean
+    suspend fun stopAudioRecording(): SamplerViewModel.SampleMetadata? // Using local SampleMetadata
+    fun getRecordingLevelPeak(): Float
+    fun isRecordingActive(): Boolean
+    suspend fun playSample(sampleId: String, /* other params for playback */): Boolean // Added for playback
+}
+
+// Placeholder for ProjectManager interface (C3)
+interface ProjectManager {
+    suspend fun addSampleToPool(name: String, sourceFileUri: String, copyToProjectDir: Boolean): SamplerViewModel.SampleMetadata? // Using local SampleMetadata
+}
+
+// Local Placeholder for SampleMetadata.
+// Ideally, this would be in a shared 'core.model' module as per README.
+// Ensure this definition is present if not already.
+data class SampleMetadata(
+    val id: String,
+    val name: String,
+    val filePathUri: String, // This would be the URI to the actual audio file
+    val durationMs: Long = 0,
+    val sampleRate: Int = 44100,
+    val channels: Int = 1,
+    val detectedBpm: Float? = null,
+    val detectedKey: String? = null,
+    var userBpm: Float? = null,
+    var userKey: String? = null,
+    var rootNote: Int = 60 // MIDI C3
+)
+
+
+enum class RecordingState {
+    IDLE,
+    ARMED,
+    RECORDING,
+    REVIEWING
+}
+
+class SamplerViewModel(
+    private val audioEngine: AudioEngineControl,
+    private val projectManager: ProjectManager
+) : ViewModel() {
+
+    private val _recordingState = MutableStateFlow(RecordingState.IDLE)
+    val recordingState: StateFlow<RecordingState> = _recordingState.asStateFlow()
+
+    private val _inputLevel = MutableStateFlow(0.0f)
+    val inputLevel: StateFlow<Float> = _inputLevel.asStateFlow()
+
+    private val _isThresholdRecordingEnabled = MutableStateFlow(false)
+    val isThresholdRecordingEnabled: StateFlow<Boolean> = _isThresholdRecordingEnabled.asStateFlow()
+
+    private val _thresholdValue = MutableStateFlow(0.1f) // Example threshold
+    val thresholdValue: StateFlow<Float> = _thresholdValue.asStateFlow()
+
+    private var lastRecordedSampleMetadata: SampleMetadata? = null
+
+    // For UI messages like errors or success
+    private val _userMessage = MutableStateFlow<String?>(null)
+    val userMessage: StateFlow<String?> = _userMessage.asStateFlow()
+
+    fun consumedUserMessage() {
+        _userMessage.value = null
+    }
+
+    init {
+        viewModelScope.launch {
+            while (true) {
+                if (_recordingState.value == RecordingState.ARMED || _recordingState.value == RecordingState.RECORDING) {
+                    // _inputLevel.value = audioEngine.getRecordingLevelPeak() // Uncomment when audioEngine is real
+                }
+                // Simulate input level for preview if needed, or remove if only real values are desired
+                if(audioEngine.isRecordingActive()){ // Basic simulation
+                     _inputLevel.value = (Math.random() * 0.7f).toFloat() + 0.1f
+                } else if (_recordingState.value != RecordingState.RECORDING) {
+                     _inputLevel.value = 0.0f
+                }
+                kotlinx.coroutines.delay(100)
+            }
+        }
+    }
+
+    fun toggleThresholdRecording(enabled: Boolean) {
+        _isThresholdRecordingEnabled.value = enabled
+        if (enabled && _recordingState.value == RecordingState.IDLE) {
+            // Optional: Automatically arm if idle and threshold is enabled
+            // _recordingState.value = RecordingState.ARMED
+        } else if (!enabled && _recordingState.value == RecordingState.ARMED) {
+            // If disabling threshold while armed, go back to idle
+            _recordingState.value = RecordingState.IDLE
+        }
+    }
+
+    fun setThresholdValue(value: Float) {
+        _thresholdValue.value = value.coerceIn(0.0f, 1.0f)
+    }
+
+    fun startRecordingPressed() {
+        if (_recordingState.value == RecordingState.IDLE || _recordingState.value == RecordingState.REVIEWING) {
+            lastRecordedSampleMetadata = null // Clear previous recording
+            if (_isThresholdRecordingEnabled.value) {
+                _recordingState.value = RecordingState.ARMED
+                _userMessage.value = "Armed for threshold recording. Make some noise!"
+                // TODO: Implement actual threshold detection logic.
+                // This would involve periodically checking audioEngine.getRecordingLevelPeak()
+                // and calling initiateRecording() when threshold is met.
+                // For now, user might need to press record again or we can simulate.
+                Log.d("SamplerVM", "Armed for threshold recording. Waiting for input > ${_thresholdValue.value}")
+
+            } else {
+                initiateRecording()
+            }
+        } else if (_recordingState.value == RecordingState.ARMED && _isThresholdRecordingEnabled.value) {
+            // If already armed by threshold, pressing record again can start immediately (manual override)
+            initiateRecording()
+        }
+    }
+
+    private fun initiateRecording() {
+        viewModelScope.launch {
+            // TODO: Use a proper file naming/management strategy from C3 or app's cache directory
+            val tempRecordingFileName = "sampler_temp_${System.currentTimeMillis()}.wav"
+            Log.d("SamplerVM", "Attempting to start recording to: $tempRecordingFileName")
+            val success = audioEngine.startAudioRecording(tempRecordingFileName, null) // null for default input device
+            if (success) {
+                _recordingState.value = RecordingState.RECORDING
+                _userMessage.value = "Recording..."
+                Log.d("SamplerVM", "Recording started successfully.")
+            } else {
+                _recordingState.value = RecordingState.IDLE
+                _userMessage.value = "Failed to start recording."
+                Log.e("SamplerVM", "AudioEngine failed to start recording.")
+            }
+        }
+    }
+
+    fun stopRecordingPressed() {
+        if (_recordingState.value == RecordingState.RECORDING || _recordingState.value == RecordingState.ARMED) {
+            viewModelScope.launch {
+                Log.d("SamplerVM", "Attempting to stop recording.")
+                val recordedMetadata = audioEngine.stopAudioRecording()
+                if (recordedMetadata != null) {
+                    lastRecordedSampleMetadata = recordedMetadata
+                    _recordingState.value = RecordingState.REVIEWING
+                    _userMessage.value = "Recording stopped. Review your sample."
+                    Log.d("SamplerVM", "Recording stopped. Metadata: $recordedMetadata")
+                } else {
+                    // If ARMED and stop is pressed before recording started, or if stopAudioRecording returns null
+                    _recordingState.value = RecordingState.IDLE
+                    _userMessage.value = "Recording stopped or no audio data."
+                    Log.d("SamplerVM", "Recording stopped, but no metadata received.")
+                }
+            }
+        }
+    }
+
+    fun playbackLastRecordingPressed() {
+        if (_recordingState.value == RecordingState.REVIEWING && lastRecordedSampleMetadata != null) {
+            viewModelScope.launch {
+                // TODO: Implement actual playback logic using audioEngine.
+                // This requires the AudioEngineControl to have a method like:
+                // suspend fun playSample(sampleId: String, filePathUri: String, /* other relevant params */)
+                // For now, we'll just log it.
+                Log.d("SamplerVM", "Playback of ${lastRecordedSampleMetadata!!.name} requested.")
+                _userMessage.value = "Playback functionality is not yet implemented."
+                // Example call if available:
+                // audioEngine.playSample(lastRecordedSampleMetadata!!.id /*, other params */)
+            }
+        }
+    }
+
+    fun saveRecording(sampleName: String, assignToPadId: String?) {
+        if (_recordingState.value == RecordingState.REVIEWING && lastRecordedSampleMetadata != null) {
+            val metadataToSave = lastRecordedSampleMetadata!!.copy(name = sampleName)
+            Log.d("SamplerVM", "Attempting to save recording: $metadataToSave")
+            viewModelScope.launch {
+                // Assuming the filePathUri in metadataToSave is the path to the temp recorded file
+                val savedMetadata = projectManager.addSampleToPool(
+                    name = metadataToSave.name,
+                    sourceFileUri = metadataToSave.filePathUri, // This URI should point to the actual temp audio file
+                    copyToProjectDir = true // As per README M1.1, copy to project
+                )
+
+                if (savedMetadata != null) {
+                    _userMessage.value = "Sample '${savedMetadata.name}' saved successfully!"
+                    Log.d("SamplerVM", "Sample saved: $savedMetadata")
+                    if (assignToPadId != null) {
+                        // TODO: Implement assignment to pad logic.
+                        // This might involve calling a method on a DrumPadViewModel or a shared service
+                        // that manages pad assignments within the current project/track.
+                        Log.d("SamplerVM", "Assigning ${savedMetadata.name} to $assignToPadId (Placeholder)")
+                        _userMessage.value = "Sample '${savedMetadata.name}' saved and assigned to $assignToPadId (Placeholder)."
+                    }
+                    _recordingState.value = RecordingState.IDLE
+                    lastRecordedSampleMetadata = null // Clear after saving
+                } else {
+                    _userMessage.value = "Failed to save sample."
+                    Log.e("SamplerVM", "ProjectManager failed to add sample to pool.")
+                    // Keep state as REVIEWING so user can try again or discard
+                }
+            }
+        } else {
+            Log.w("SamplerVM", "Save recording called in invalid state or with no metadata.")
+        }
+    }
+
+    fun discardRecording() {
+        if (_recordingState.value == RecordingState.REVIEWING) {
+            Log.d("SamplerVM", "Discarding recording: ${lastRecordedSampleMetadata?.name}")
+            // TODO: Optionally, delete the temporary recording file from disk
+            // This would require knowing the filePathUri and using file system operations.
+            // For now, just clear the metadata.
+            lastRecordedSampleMetadata = null
+            _recordingState.value = RecordingState.IDLE
+            _userMessage.value = "Recording discarded."
+        }
+    }
+    // NOTE: The SampleMetadata class definition was moved up to be with the interfaces
+    // to match the provided code structure. No change needed here if it's already moved.
+}

--- a/app/src/test/java/com/example/theone/features/sampler/SamplerViewModelTest.kt
+++ b/app/src/test/java/com/example/theone/features/sampler/SamplerViewModelTest.kt
@@ -1,0 +1,208 @@
+package com.example.theone.features.sampler
+
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher // Explicit import for TestWatcher
+
+@ExperimentalCoroutinesApi
+class SamplerViewModelTest {
+
+    // Rule for JUnit to use TestCoroutineDispatcher
+    // This helps in controlling the execution of coroutines in tests
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule() // See MainCoroutineRule definition below
+
+    private lateinit var viewModel: SamplerViewModel
+    private lateinit var mockAudioEngine: AudioEngineControl
+    private lateinit var mockProjectManager: ProjectManager
+
+    // Mocked SampleMetadata for consistent testing
+    private val fakeSampleMetadata = SamplerViewModel.SampleMetadata(
+        id = "test_id",
+        name = "test_sample",
+        filePathUri = "fake/path/to/sample.wav"
+    )
+
+    @Before
+    fun setUp() {
+        // Create mocks for the dependencies
+        mockAudioEngine = mockk(relaxed = true) // relaxed = true allows skipping `every { ... } returns ...` for all methods
+        mockProjectManager = mockk(relaxed = true)
+
+        // Create an instance of the ViewModel with the mocked dependencies
+        viewModel = SamplerViewModel(mockAudioEngine, mockProjectManager)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll() // Clear all mocks after each test
+    }
+
+    @Test
+    fun `initial state is IDLE`() = runTest {
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+    }
+
+    @Test
+    fun `startRecordingPressed without threshold success`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+
+        viewModel.startRecordingPressed()
+
+        assertEquals(RecordingState.RECORDING, viewModel.recordingState.first())
+        coVerify { mockAudioEngine.startAudioRecording(any(), null) }
+    }
+
+    @Test
+    fun `startRecordingPressed without threshold failure`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns false
+
+        viewModel.startRecordingPressed()
+
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+        assertEquals("Failed to start recording.", viewModel.userMessage.first())
+    }
+
+    @Test
+    fun `startRecordingPressed with threshold enabled arms the viewModel`() = runTest {
+        viewModel.toggleThresholdRecording(true)
+        viewModel.startRecordingPressed()
+        assertEquals(RecordingState.ARMED, viewModel.recordingState.first())
+        assertEquals("Armed for threshold recording. Make some noise!", viewModel.userMessage.first())
+    }
+
+    @Test
+    fun `stopRecordingPressed while recording success`() = runTest {
+        // Start recording first
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed() // Puts state to RECORDING
+
+        coEvery { mockAudioEngine.stopAudioRecording() } returns fakeSampleMetadata
+
+        viewModel.stopRecordingPressed()
+
+        assertEquals(RecordingState.REVIEWING, viewModel.recordingState.first())
+        assertEquals("Recording stopped. Review your sample.", viewModel.userMessage.first())
+        coVerify { mockAudioEngine.stopAudioRecording() }
+    }
+
+    @Test
+    fun `stopRecordingPressed while recording but no metadata returned`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed()
+
+        coEvery { mockAudioEngine.stopAudioRecording() } returns null // Simulate failure or no data
+
+        viewModel.stopRecordingPressed()
+
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+        assertEquals("Recording stopped or no audio data.", viewModel.userMessage.first())
+    }
+
+
+    @Test
+    fun `saveRecording success`() = runTest {
+        // Go to REVIEWING state first
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed()
+        coEvery { mockAudioEngine.stopAudioRecording() } returns fakeSampleMetadata
+        viewModel.stopRecordingPressed() // Now in REVIEWING with lastRecordedSampleMetadata set
+
+        val newSampleName = "My New Sample"
+        val expectedSavedMetadata = fakeSampleMetadata.copy(name = newSampleName)
+        coEvery { mockProjectManager.addSampleToPool(newSampleName, fakeSampleMetadata.filePathUri, true) } returns expectedSavedMetadata
+
+        viewModel.saveRecording(newSampleName, null)
+
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+        assertEquals("Sample '${expectedSavedMetadata.name}' saved successfully!", viewModel.userMessage.first())
+        coVerify { mockProjectManager.addSampleToPool(newSampleName, fakeSampleMetadata.filePathUri, true) }
+    }
+
+    @Test
+    fun `saveRecording success with pad assignment (placeholder verification)`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed()
+        coEvery { mockAudioEngine.stopAudioRecording() } returns fakeSampleMetadata
+        viewModel.stopRecordingPressed()
+
+        val newSampleName = "My Sample For Pad"
+        val padToAssign = "Pad5"
+        val expectedSavedMetadata = fakeSampleMetadata.copy(name = newSampleName)
+        coEvery { mockProjectManager.addSampleToPool(newSampleName, fakeSampleMetadata.filePathUri, true) } returns expectedSavedMetadata
+
+        viewModel.saveRecording(newSampleName, padToAssign)
+
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+        assertEquals("Sample '${expectedSavedMetadata.name}' saved and assigned to $padToAssign (Placeholder).", viewModel.userMessage.first())
+    }
+
+
+    @Test
+    fun `saveRecording failure`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed()
+        coEvery { mockAudioEngine.stopAudioRecording() } returns fakeSampleMetadata
+        viewModel.stopRecordingPressed()
+
+        val newSampleName = "Failed Sample"
+        coEvery { mockProjectManager.addSampleToPool(any(), any(), any()) } returns null // Simulate failure
+
+        viewModel.saveRecording(newSampleName, null)
+
+        assertEquals(RecordingState.REVIEWING, viewModel.recordingState.first()) // Should remain in reviewing
+        assertEquals("Failed to save sample.", viewModel.userMessage.first())
+    }
+
+    @Test
+    fun `discardRecording success`() = runTest {
+        coEvery { mockAudioEngine.startAudioRecording(any(), any()) } returns true
+        viewModel.startRecordingPressed()
+        coEvery { mockAudioEngine.stopAudioRecording() } returns fakeSampleMetadata
+        viewModel.stopRecordingPressed() // State is REVIEWING
+
+        viewModel.discardRecording()
+
+        assertEquals(RecordingState.IDLE, viewModel.recordingState.first())
+        assertEquals("Recording discarded.", viewModel.userMessage.first())
+    }
+}
+
+// Helper class for managing CoroutineDispatchers in tests
+// Standard MainCoroutineRule from kotlinx-coroutines-test documentation
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    private val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher() { // TestWatcher is from JUnit
+
+    override fun starting(description: org.junit.runner.Description?) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: org.junit.runner.Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+}
+
+// If TestCoroutineDispatcher is not available (older kotlinx-coroutines-test)
+// you might need a slightly different setup for MainCoroutineRule, or use runTest directly.
+// For example, with kotlinx-coroutines-test >= 1.6.0, TestCoroutineDispatcher is deprecated.
+// You'd use something like:
+// val testDispatcher = StandardTestDispatcher()
+// or
+// val testDispatcher = UnconfinedTestDispatcher()
+
+// For simplicity with the current environment, the provided MainCoroutineRule with TestCoroutineDispatcher is common.
+// If issues arise, it might be due to library versions. The subtask should still create the file.
+// The key is that `runTest` from kotlinx-coroutines-test is used for coroutine tests.


### PR DESCRIPTION
Adds the foundational UI and ViewModel for the M1.1 Sampler recording module.

Key components:
- SamplerViewModel: Manages recording states (IDLE, ARMED, RECORDING, REVIEWING), handles interactions with placeholder AudioEngineControl (C1) and ProjectManager (C3) services for recording, stopping, and saving samples. Includes StateFlows for UI updates (recording state, input level, user messages).
- SamplerScreen (Jetpack Compose): Provides the UI for sampler operations, including record/stop buttons, threshold recording controls (basic), input level display (simulated), and dialogs for naming and assigning samples (assigning is a placeholder).
- SamplerViewModelTest: Basic unit tests for SamplerViewModel using MockK, covering initial state, state transitions for recording lifecycle, and interactions with mocked dependencies.

This implementation aligns with the M1.1 module requirements defined in the project's README.md. It lays the groundwork for further development of sample recording, editing, and integration with core audio and project management services.

Note:
- C1 (AudioEngine) and C3 (ProjectManager) are currently placeholder interfaces within the SamplerViewModel.
- Input level indication in the UI is based on simulated data.
- Threshold recording logic requires further implementation with actual audio analysis.
- Pad assignment is a placeholder and will require integration with DrumPadViewModel/Track management.